### PR TITLE
Add double quotes around file paths to fix #11

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ export function buildFormatCommand(path: string): string {
   const msn: boolean = settings.get("makeSummaryMultiline") || false;
   const fw: boolean = settings.get("forceWrap") || false;
   return c`
-    docformatter ${path} --wrap-summaries ${wsl} --wrap-descriptions ${wdl}
+    docformatter "${path}" --wrap-summaries ${wsl} --wrap-descriptions ${wdl}
     ${psn ? "--blank" : ""}
     ${msn ? "--make-summary-multi-line" : ""}
     ${fw ? "--force-wrap" : ""}

--- a/src/test/example with spaces in name.py
+++ b/src/test/example with spaces in name.py
@@ -1,0 +1,30 @@
+"""Example file for testing."""
+
+
+def function_with_good_docstring(param: str) -> bool:
+    """This is a well-formatted docstring.
+
+    It has a longer description here as well.
+
+    # Arguments
+        param (str): A parameter that is passed to the function.
+
+    # Returns
+        bool: A boolean value.
+    """
+    return bool(param)
+
+
+def function_with_bad_docstring(param: str) -> bool:
+    '''
+This is a badly-formatted docstring.
+    It has a longer description here as well. But it's way too long to fit the line that it is in. It just keeps going on and on. And the author didn't put any line breaks in.
+
+    It should not use single quotes or have trailing whitespace.
+
+    # Arguments
+        param (str): A parameter that is passed to the function.
+
+    # Returns       
+        bool: A boolean value. '''
+    return bool(param)

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -7,7 +7,7 @@ const testPythonFiles: Readonly<Record<string, string>> = {
   /** The basic test file with no quirks. */
   base: "/../../src/test/example.py",
   /** A test file where the path contains spaces. */
-  spacesInName: "/../../src/test/example with spaces in names.py"
+  spacesInName: "/../../src/test/example with spaces in name.py"
 };
 /** Extension identifier. */
 const identifier = "iansan5653.format-python-docstrings";

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -227,7 +227,7 @@ describe("extension.ts", function(): void {
       it("should implement the correct defaults", function(): void {
         assert.strictEqual(
           ext.buildFormatCommand("path"),
-          "docformatter path --wrap-summaries 79 --wrap-descriptions 72"
+          "docformatter \"path\" --wrap-summaries 79 --wrap-descriptions 72"
         );
       });
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -55,15 +55,17 @@ describe("extension.ts", function(): void {
       documents.spacesInName = documentsList[1];
     });
 
-    describe("#activate()", function(): Promise<void> {
+    describe("#activate()", function(): void {
       // Waits until the extension is active, but will eventually time out if
       // not
-      return new Promise((res): void => {
-        setInterval((): void => {
-          if (extension.isActive) {
-            res();
-          }
-        }, 50);
+      it("should successfully activate the extension on file opening", function(): Promise<void> {
+        return new Promise((res): void => {
+          setInterval((): void => {
+            if (extension.isActive) {
+              res();
+            }
+          }, 50);
+        });
       });
     });
 

--- a/src/test/run-tests-insiders.ts
+++ b/src/test/run-tests-insiders.ts
@@ -14,7 +14,7 @@ async function main(): Promise<void> {
     });
   } catch (err) {
     console.error("Failed to run tests");
-    process.exit(1);
+    process.exit(-1);
   }
 }
 

--- a/src/test/run-tests-stable.ts
+++ b/src/test/run-tests-stable.ts
@@ -14,7 +14,7 @@ async function main(): Promise<void> {
     });
   } catch (err) {
     console.error("Failed to run tests");
-    process.exit(1);
+    process.exit(-1);
   }
 }
 


### PR DESCRIPTION
Adds support for file paths containing spaces by wrapping all file paths in double quotes. Also adds tests for such situations.