### PR TITLE
Greenkeeper/@typescript eslint/parser 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,32 +108,32 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.8.0.tgz",
-			"integrity": "sha512-NseXWzhkucq+JM2HgqAAoKEzGQMb5LuTRjFPLQzGIdLthXMNUfuiskbl7QSykvWW6mvzCtYbw1fYWGa2EIaekw==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.10.0.tgz",
+			"integrity": "sha512-wQNiBokcP5ZsTuB+i4BlmVWq6o+oAhd8en2eSm/EE9m7BgZUIfEeYFd6z3S+T7bgNuloeiHA1/cevvbBDLr98g==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "2.8.0",
-				"@typescript-eslint/typescript-estree": "2.8.0",
+				"@typescript-eslint/experimental-utils": "2.10.0",
+				"@typescript-eslint/typescript-estree": "2.10.0",
 				"eslint-visitor-keys": "^1.1.0"
 			},
 			"dependencies": {
 				"@typescript-eslint/experimental-utils": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.8.0.tgz",
-					"integrity": "sha512-jZ05E4SxCbbXseQGXOKf3ESKcsGxT8Ucpkp1jiVp55MGhOvZB2twmWKf894PAuVQTCgbPbJz9ZbRDqtUWzP8xA==",
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz",
+					"integrity": "sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==",
 					"dev": true,
 					"requires": {
 						"@types/json-schema": "^7.0.3",
-						"@typescript-eslint/typescript-estree": "2.8.0",
+						"@typescript-eslint/typescript-estree": "2.10.0",
 						"eslint-scope": "^5.0.0"
 					}
 				},
 				"@typescript-eslint/typescript-estree": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.8.0.tgz",
-					"integrity": "sha512-ksvjBDTdbAQ04cR5JyFSDX113k66FxH1tAXmi+dj6hufsl/G0eMc/f1GgLjEVPkYClDbRKv+rnBFuE5EusomUw==",
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz",
+					"integrity": "sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==",
 					"dev": true,
 					"requires": {
 						"debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^12.12.8",
     "@types/vscode": "^1.40.0",
     "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.8.0",
+    "@typescript-eslint/parser": "^2.10.0",
     "eslint": "^6.6.0",
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-jsdoc": "^18.3.0",


### PR DESCRIPTION
Build failed earlier due to Pipelines issues that have been resolved.